### PR TITLE
Removes Phase 08 scope from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,6 @@
 
 Thank you for your interest in contributing! We are in Phase 08 (Documentation). Focus on improving developer experience: docs completeness, samples, and accuracy matching the code.
 
-## Scope for Phase 08
-
-- Update README with run/test instructions, endpoints, samples, error handling, security, observability, and architecture notes
-- Keep CONTRIBUTING current (this file)
-- Ensure docker-compose and local run are reflected accurately
-- Add missing samples or clarifications discovered during a dry-run
-
 ## Branching / PRs
 
 - Branch from `main` or the current phase branch as instructed in issues


### PR DESCRIPTION
Removes the specific Phase 08 scope section from the contributing guide.

The information is no longer relevant.
